### PR TITLE
Develop/tests (#3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(WordCharts)
 
 set(CMAKE_CXX_STANDARD 17)
 
-set(CMAKE_AUTOUIC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
@@ -28,6 +29,9 @@ qt_add_qml_module(WordCharts
             src/word_streams/WordStream.hpp
             src/word_streams/FileWordStream.cpp
 )
+
+include(src/word_streams/tests/TestFileWordStream.cmake)
+include(src/proxy_models/tests/TestWordsFrequentProxy.cmake)
 
 target_link_libraries(WordCharts PRIVATE Qt6::Core Qt6::Widgets Qt6::Gui Qt6::Quick Qt6::Qml)
 target_include_directories(WordCharts PUBLIC src)

--- a/src/WordData.cpp
+++ b/src/WordData.cpp
@@ -4,8 +4,6 @@
 
 #include "WordData.hpp"
 
-#include <utility>
-
 WordData::WordData(const QString& word, const QString& doc, quint32 count)
     : _word(word),
       _file(doc),

--- a/src/WordData.hpp
+++ b/src/WordData.hpp
@@ -8,15 +8,16 @@
 #include <QString>
 
 struct WordData {
+    WordData() = default;
     WordData(const QString& word, const QString& doc, quint32 count = 1);
 
     bool operator== (const WordData& right) const;
     bool operator< (const WordData& right) const;
     bool operator> (const WordData& right) const;
 
-    QString _word;
-    QString _file;
-    quint32 _count;
+    QString _word{};
+    QString _file{};
+    quint32 _count{};
 };
 
 #endif    //WORDCHARTS_WORDDATA_HPP

--- a/src/WordFrequencyAnalystWorker.cpp
+++ b/src/WordFrequencyAnalystWorker.cpp
@@ -7,8 +7,8 @@
 WordFrequencyAnalystWorker::WordFrequencyAnalystWorker(const QString& file_path,
                                                        proxy_models::WordsFrequentProxy* frequent_proxy)
     : _frequent_proxy(frequent_proxy), _file_path(file_path) {
-    connect(&_tree, &count_classes::CountClass::countChanged, this, &WordFrequencyAnalystWorker::onCountChanged);
-    connect(&_tree, &count_classes::CountClass::newWord, this, &WordFrequencyAnalystWorker::onNewWord);
+    connect(&_tree, &count_classes::CountClass::countChanged, _frequent_proxy, &proxy_models::WordsFrequentProxy::onUpdateData);
+    connect(&_tree, &count_classes::CountClass::newWord, _frequent_proxy, &proxy_models::WordsFrequentProxy::onNewData);
 }
 
 void WordFrequencyAnalystWorker::work() {
@@ -83,12 +83,4 @@ void WordFrequencyAnalystWorker::unPause() {
 void WordFrequencyAnalystWorker::stop() {
     dropProgress();
     _stop_required = true;
-}
-
-void WordFrequencyAnalystWorker::onCountChanged(const QString& word, quint32 count) {
-    _frequent_proxy->updateData(word, count);
-}
-
-void WordFrequencyAnalystWorker::onNewWord(const QString& word, quint32 count) {
-    _frequent_proxy->newData(word, count);
 }

--- a/src/WordFrequencyAnalystWorker.hpp
+++ b/src/WordFrequencyAnalystWorker.hpp
@@ -27,8 +27,6 @@ signals:
     void errorOccured(QString error);
     void finished();
 public slots:
-    void onCountChanged(const QString& word, quint32 count);
-    void onNewWord(const QString& word, quint32 count);
     void work();
     void stop();
 

--- a/src/proxy_models/WordsFrequentProxy.cpp
+++ b/src/proxy_models/WordsFrequentProxy.cpp
@@ -10,7 +10,7 @@ namespace proxy_models {
         : _max_amount(max_amount),
           _filename(filename) {}
 
-    void WordsFrequentProxy::newData(const QString& word, quint32 count) {
+    void WordsFrequentProxy::onNewData(const QString& word, quint32 count) {
         WordData wd{word, _filename, count};
         _words_count.push_back(wd);
         //Если прокси коллекция еще не содержит _max_amount элементов, мы отправляем сигнал об изменении данных в
@@ -26,10 +26,10 @@ namespace proxy_models {
         }
     }
 
-    //Метод updateData увеличивает счетчик вхождения слова в документ и отправляет сигналы на изменение данных в модели
+    //Метод onUpdateData увеличивает счетчик вхождения слова в документ и отправляет сигналы на изменение данных в модели
     //Элементы встречающиеся чаще всего в тексте - первые _max_amount элементов (топовые элементы)
     //Элемент среди первых _max_amount с самым малым значением _count - Самый редкий среди первых _max_amount элементов (редчайший топовый)
-    void WordsFrequentProxy::updateData(const QString& word, quint32 count) {
+    bool WordsFrequentProxy::onUpdateData(const QString& word, quint32 count) {
         WordData wd{word, _filename, count};
         //Находим элемент с тем же словом и файлом в списке (на случай непредвиденных ошибок, индекс проверяется на валидность)
         qsizetype ind = _words_count.indexOf(wd);
@@ -51,6 +51,8 @@ namespace proxy_models {
                 _min_count_pos = min_elem - _words_count.begin();
                 _min_count = min_elem->_count;
             }
+            return true;
         }
+        return false;
     }
 }    //namespace proxy_models

--- a/src/proxy_models/WordsFrequentProxy.hpp
+++ b/src/proxy_models/WordsFrequentProxy.hpp
@@ -7,7 +7,7 @@
 
 #include <QObject>
 
-#include "WordData.hpp"
+#include "src/WordData.hpp"
 
 namespace proxy_models {
     //Данный класс обрабатывает данные для модели и передает их посредством сигналов
@@ -18,8 +18,9 @@ namespace proxy_models {
         Q_OBJECT
     public:
         explicit WordsFrequentProxy(const QString& filename, qint64 max_amount);
-        void newData(const QString& word, quint32 count);
-        void updateData(const QString& word, quint32 count);
+    public slots:
+        void onNewData(const QString& word, quint32 count);
+        bool onUpdateData(const QString& word, quint32 count);
 
     signals:
         void newModelData(const WordData&);

--- a/src/proxy_models/tests/TestWordsFrequentProxy.cmake
+++ b/src/proxy_models/tests/TestWordsFrequentProxy.cmake
@@ -1,0 +1,9 @@
+enable_testing(true)
+
+find_package(Qt6 REQUIRED COMPONENTS Test)
+
+add_executable(testWordsFrequentProxy src/WordData.cpp src/proxy_models/tests/TestWordsFrequentProxy.cpp src/proxy_models/WordsFrequentProxy.cpp)
+
+add_test(NAME testWordsFrequentProxy COMMAND testWordsFrequentProxy)
+
+target_link_libraries(testWordsFrequentProxy PRIVATE Qt6::Test)

--- a/src/proxy_models/tests/TestWordsFrequentProxy.cpp
+++ b/src/proxy_models/tests/TestWordsFrequentProxy.cpp
@@ -1,0 +1,80 @@
+//
+// Created by nyanbanan on 17.01.24.
+//
+
+#include "TestWordsFrequentProxy.hpp"
+
+QTEST_MAIN(proxy_models::tests::TestWordsFrequentProxy)
+
+namespace proxy_models::tests {
+    void TestWordsFrequentProxy::newData_data() {
+        //Тестовые данные, word - слово для вставки, count - кол-во вхождений слова в коллекцию
+        //Сигнал newModelData должен вернуть то же значение в поле _count, что и передано в метод onNewData
+        QTest::addColumn<QStack<testWord>>("test_case");
+        QTest::addColumn<qint64>("max_amount");
+
+        QStack<testWord> test_case{{{"Пингвинусы", 1}, {"Пингвинята", 1}, {"Пингвин", 3}, {"Пинг", 4}}};
+        QTest::addRow("first_case") << test_case << qint64(3);
+    }
+
+    void TestWordsFrequentProxy::newData() {
+        QFETCH(QStack<testWord>, test_case);
+
+        QString file_name{""};
+        WordsFrequentProxy proxy{file_name, test_case.size()};
+
+        QSignalSpy signal_spy(&proxy, &WordsFrequentProxy::newModelData);
+        for (auto [str, count] : test_case) {
+            proxy.onNewData(str, count);
+            auto signal = signal_spy.takeFirst();
+            auto arg = signal.at(0).value<WordData>();
+            QCOMPARE(arg._file, file_name);
+            QCOMPARE(arg._word, str);
+            QCOMPARE(arg._count, count);
+        }
+    }
+
+    void TestWordsFrequentProxy::updateData_data() {
+        //Данные для инициализации прокси модели word - слово для вставки, count - кол-во вхождений слова в коллекцию
+        QTest::addColumn<QStack<testWord>>("start_data");
+        //Тестовые данные: word - слово для обновления, count - кол-во вхождений слова в коллекцию
+        //new_data._count cигнала updateModelData должен быть равен count
+        //Если равен 0 - сигнал не должен быть вызван, следовательно signal_spy.count должен быть равен 0
+        QTest::addColumn<QStack<testWord>>("test_case");
+
+        QStack<testWord> start_data_1{{{"Пингвинусы", 1}, {"Пингвинята", 1}, {"Пингвин", 3}, {"Пинг", 4}}};
+        QStack<testWord> test_case_1{{{"Пинг", 5}, {"Слово", 0}, {"Слово", 2}}};
+
+        QTest::addRow("first_case") << start_data_1 << test_case_1;
+    }
+
+    void TestWordsFrequentProxy::updateData() {
+        QFETCH(QStack<testWord>, start_data);
+        QFETCH(QStack<testWord>, test_case);
+
+        QString file_name{""};
+        WordsFrequentProxy proxy{file_name, start_data.size()};
+
+        for (auto [str, count] : start_data) {
+            proxy.onNewData(str, count);
+        }
+
+        QSignalSpy signal_spy(&proxy, &WordsFrequentProxy::updateModelData);
+        for (auto [str, count] : test_case) {
+            //Обновляем данные о вхождениях слова в коллекцию (добавляем 1 вхождение уже существующему слову)
+            if(proxy.onUpdateData(str, 1)){
+                //Если слово есть в коллекции, то проверяем приходящий сигнал
+                auto signal = signal_spy.takeFirst();
+                auto arg = signal.at(1).value<WordData>();
+                QCOMPARE(arg._file, file_name);
+                QCOMPARE(arg._word, str);
+                QCOMPARE(arg._count, count);
+            }
+            else{
+                //Если слова не было в коллекции, то добавляем его, при этом не должно быть инициировано сигналов updateModelData
+                proxy.onNewData(str, 1);
+                QVERIFY(signal_spy.count() == 0);
+            }
+        }
+    }
+}    //namespace proxy_models::tests

--- a/src/proxy_models/tests/TestWordsFrequentProxy.hpp
+++ b/src/proxy_models/tests/TestWordsFrequentProxy.hpp
@@ -1,0 +1,30 @@
+//
+// Created by nyanbanan on 17.01.24.
+//
+
+#ifndef WORDCHARTS_TESTWORDSFREQUENTPROXY_HPP
+#define WORDCHARTS_TESTWORDSFREQUENTPROXY_HPP
+
+#include <QObject>
+#include <QtTest/QtTest>
+#include <QSignalSpy>
+
+#include "src/WordData.hpp"
+#include "../WordsFrequentProxy.hpp"
+
+namespace proxy_models::tests {
+    struct testWord{
+        QString word;
+        quint32 count;
+    };
+
+    class TestWordsFrequentProxy : public QObject {
+        Q_OBJECT
+    private slots:
+        void newData_data();
+        void newData();
+        void updateData_data();
+        void updateData();
+    };
+}
+#endif    //WORDCHARTS_TESTWORDSFREQUENTPROXY_HPP

--- a/src/word_streams/tests/TestFileWordStream.cmake
+++ b/src/word_streams/tests/TestFileWordStream.cmake
@@ -1,0 +1,9 @@
+enable_testing(true)
+
+find_package(Qt6 REQUIRED COMPONENTS Test Qml)
+
+add_executable(testWordCharts src/word_streams/tests/TestFileWordStream.cpp src/word_streams/FileWordStream.cpp)
+
+add_test(NAME testWordCharts COMMAND testWordCharts)
+
+target_link_libraries(testWordCharts PRIVATE Qt6::Test Qt6::Qml)

--- a/src/word_streams/tests/TestFileWordStream.cpp
+++ b/src/word_streams/tests/TestFileWordStream.cpp
@@ -1,0 +1,41 @@
+//
+// Created by nyanbanan on 17.01.24.
+//
+
+#include "TestFileWordStream.hpp"
+
+QTEST_MAIN(word_streams::tests::TestFileWordStream)
+namespace word_streams::tests {
+    void TestFileWordStream::initTestCase_data() {
+        QTest::addColumn<QByteArray>("test_string");
+
+        QByteArray test_str{"test"};
+
+        QTest::addRow("test_str_for_all_tests") << test_str;
+    }
+
+    void TestFileWordStream::getNextWord() {
+        QFETCH_GLOBAL(QByteArray, test_string);
+
+        QBuffer device{&test_string};
+        device.open(QIODevice::ReadOnly);
+
+        stream.setDevice(&device);
+
+        auto res = stream.getNextWord();
+        QCOMPARE(res, test_string);
+    }
+
+    void TestFileWordStream::pushNextWord() {
+        QFETCH_GLOBAL(QByteArray, test_string);
+
+        QBuffer device{&test_string};
+        device.open(QIODevice::ReadOnly);
+
+        stream.setDevice(&device);
+
+        QByteArray res;
+        stream.pushNextWord(res);
+        QCOMPARE(res, test_string);
+    }
+}    //namespace word_streams::tests

--- a/src/word_streams/tests/TestFileWordStream.hpp
+++ b/src/word_streams/tests/TestFileWordStream.hpp
@@ -1,0 +1,25 @@
+//
+// Created by nyanbanan on 17.01.24.
+//
+
+#ifndef WORDCHARTS_TESTFILEWORDSTREAM_HPP
+#define WORDCHARTS_TESTFILEWORDSTREAM_HPP
+
+#include <QObject>
+#include <QtTest/QtTest>
+
+#include "../FileWordStream.hpp"
+
+namespace word_streams::tests {
+    class TestFileWordStream: public QObject {
+    Q_OBJECT
+    private slots:
+        void initTestCase_data();
+        void getNextWord();
+        void pushNextWord();
+    private:
+        FileWordStream stream;
+    };
+}    //namespace word_streams::tests
+
+#endif    //WORDCHARTS_TESTFILEWORDSTREAM_HPP


### PR DESCRIPTION
* Added:
- TestWordsFrequentProxy

* Deleted:
- WordFrequencyAnalystWorker transitional signals onCountChanged and onNewWord Changes:
- WordsFrequentProxy methods changed to slots (newData -> onNewData, updateData -> onUpdateData)
- Connections in WordFrequencyAnalystWorker constructor changed

* Added:
- WordData's default constructor for QVariant.convert work
- TestWordsFrequentProxy

* Added:
- TestWordsFrequentProxy onUpdateData test Changes:
- WordsFrequentProxy onUpdateData now have bool return value